### PR TITLE
Add updated items when we update article

### DIFF
--- a/Handler/Nomnichi.hs
+++ b/Handler/Nomnichi.hs
@@ -100,10 +100,12 @@ postArticleR articleId = do
         update articleId
           [ ArticleMemberName =. articleMemberName article
           , ArticleTitle   =. articleTitle   article
+          , ArticlePermaLink =. articlePermaLink article
           , ArticleContent =. articleContent article
           , ArticleUpdatedOn =. articleUpdatedOn article
           , ArticlePublishedOn =. articlePublishedOn article
           , ArticleApproved =. articleApproved article
+          , ArticlePromoteHeadline =. articlePromoteHeadline  article
           ]
       setMessage $ toHtml $ (articleTitle article) <> " is updated."
       redirect $ ArticleR articleId


### PR DESCRIPTION
記事を再編集した際に，「PermaLink」と「PromoteHeadline」が更新されない不具合を修正
