### PR TITLE
This commit fixes #15

### DIFF
--- a/Handler/Nomnichi.hs
+++ b/Handler/Nomnichi.hs
@@ -171,7 +171,7 @@ entryForm = renderDivs $ Article
   <$> areq textField    "MemberName"   Nothing
   <*> areq textField    "Title"        Nothing
   <*> areq textField    "PermaLink"    Nothing
-  <*> areq nicHtmlField "Content"      Nothing
+  <*> areq htmlField "Content"      Nothing
   <*> lift (liftIO getCurrentTime) --
   <*> lift (liftIO getCurrentTime) --
   <*> lift (liftIO getCurrentTime) --
@@ -184,7 +184,7 @@ editForm article = renderDivs $ Article
   <$> areq textField    "MemberName" (articleMemberName <$> article)
   <*> areq textField    "Title"    (articleTitle <$> article)
   <*> areq textField    "PermaLink"  (articlePermaLink <$> article)
-  <*> areq nicHtmlField "Content"  (articleContent <$> article)
+  <*> areq htmlField "Content"  (articleContent <$> article)
   <*> lift (liftIO getCurrentTime)
   <*> lift (liftIO getCurrentTime)
   <*> lift (liftIO getCurrentTime)


### PR DESCRIPTION
#15 で言及されている問題は，現在Nomnichiが用いているNicEditのバグの可能性がある．

このため，考えられる対処法は以下の3つである．
1. 利用するYesod.Form.Nic のバージョンを変更する．
2. NicEditをCKEditorなどの他のエディタに変更する．
3. Editorを利用せず，単にhtml直書きのフォームに変更する．
このプルリクでは，上記のうちの 3 を採用した．
理由は，htmlを直に編集する画面が多いことと，Editorには誰からも利用されていない機能が多いことである．
