### PR TITLE
Fix article preview

### DIFF
--- a/templates/createArticleForm.julius
+++ b/templates/createArticleForm.julius
@@ -2,8 +2,8 @@ var renderPreview = function(event){
   var previewArea = $("div.article_preview")
 
   event.preventDefault();
-  var title = $("input[id=h2][name=f2]").val();
-  var content = $("div.nicEdit-main").html();
+  var title = document.getElementById("hident3").value;
+  var content = document.getElementById("hident5").value;
 
   previewArea.empty();
   previewArea.append("<hr>");

--- a/templates/editArticleForm.julius
+++ b/templates/editArticleForm.julius
@@ -2,8 +2,8 @@ var renderPreview = function(event){
   var previewArea = $("div.article_preview")
 
   event.preventDefault();
-  var title = $("input[id=h2][name=f2]").val();
-  var content = $("div.nicEdit-main").html();
+  var title = document.getElementById("hident3").value;
+  var content = document.getElementById("hident5").value;
 
   previewArea.empty();
   previewArea.append("<hr>");


### PR DESCRIPTION
This commit fixes #20.
記事作成・編集フォームをNicEditからプレーンhtmlに変更したことにより，
タイトルだけでなく本文のプレビューも閲覧出来なくなっていた．
このため，タイトルがプレビューに表示されない問題に加え，本文のプレビューについても修正した．
