### PR TITLE
Be able to answer in the HEAD request

### DIFF
--- a/Application.hs
+++ b/Application.hs
@@ -53,7 +53,7 @@ makeApplication conf = do
         }
 
     -- Create the WAI application and apply middlewares
-    app <- toWaiAppPlain foundation
+    app <- toWaiApp foundation
     let logFunc = messageLoggerSource foundation (appLogger foundation)
     return (logWare app, logFunc)
 


### PR DESCRIPTION
nomnichi に HEAD リクエストを飛ばすと， 405 Method Not Allowed が返ってくる．
これは，サーバは GET メソッドと HEAD メソッドは必ずサポートしなければならないという
HTTPの規約に反している．
このため，HEAD リクエストをサポートした．

具体的には，以下のページを参考に toWaiAppPlain を toWaiApp に変更した．
http://www.yesodweb.com/book/yesod-for-haskellers

変更後 200 OK が返ってくることを確認した．
